### PR TITLE
SCRUM-4260 - Modifications for allowing using last successful data fetched by "scrapers" in case of errors

### DIFF
--- a/src/main/java/net/apnic/rdap/iana/config/IANAConfiguration.java
+++ b/src/main/java/net/apnic/rdap/iana/config/IANAConfiguration.java
@@ -4,6 +4,7 @@ import net.apnic.rdap.authority.RDAPAuthorityStore;
 import net.apnic.rdap.iana.scraper.IANABootstrapFetcher;
 import net.apnic.rdap.iana.scraper.IANABootstrapScraper;
 
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.context.annotation.Bean;
@@ -25,13 +26,14 @@ public class IANAConfiguration
 
     @ConditionalOnProperty(value="rdap.scraping.scrapers.iana.enabled")
     @Bean(value="iana")
-    public IANABootstrapScraper ianaScraper()
+    @Autowired
+    public IANABootstrapScraper ianaScraper(RDAPAuthorityStore rdapAuthorityStore)
     {
         if(baseURI != null && baseURI.isEmpty() == false)
         {
-            return new IANABootstrapScraper(new IANABootstrapFetcher(baseURI));
+            return new IANABootstrapScraper(rdapAuthorityStore, new IANABootstrapFetcher(baseURI));
         }
-        return new IANABootstrapScraper();
+        return new IANABootstrapScraper(rdapAuthorityStore);
     }
 
     public void setBaseURI(String baseURI)

--- a/src/main/java/net/apnic/rdap/iana/scraper/IANABootstrapFetcher.java
+++ b/src/main/java/net/apnic/rdap/iana/scraper/IANABootstrapFetcher.java
@@ -1,18 +1,11 @@
 package net.apnic.rdap.iana.scraper;
 
 import com.fasterxml.jackson.databind.JsonNode;
+import org.springframework.http.*;
+import org.springframework.web.client.RestTemplate;
 
-import java.util.concurrent.CompletableFuture;
 import java.net.URI;
 import java.util.Arrays;
-
-import org.springframework.http.HttpEntity;
-import org.springframework.http.HttpHeaders;
-import org.springframework.http.HttpMethod;
-import org.springframework.http.MediaType;
-import org.springframework.http.ResponseEntity;
-import org.springframework.web.client.RestClientException;
-import org.springframework.web.client.RestTemplate;
 
 public class IANABootstrapFetcher
 {
@@ -54,21 +47,11 @@ public class IANABootstrapFetcher
         this.useBaseURI = baseURI;
     }
 
-    public CompletableFuture<BootstrapResult> makeRequestForType(RequestType requestType) {
+    public BootstrapResult makeRequestForType(RequestType requestType) {
         HttpEntity<?> entity = new HttpEntity<>(REQUEST_HEADERS);
-        CompletableFuture<BootstrapResult> future =
-            new CompletableFuture<BootstrapResult>();
-
-        try {
-            ResponseEntity<JsonNode> rEntity =
-                restClient.exchange(requestType.getRequestURI(useBaseURI),
-                    HttpMethod.GET, entity, JsonNode.class);
-
-            future.complete(BootstrapResultParser.parse(rEntity.getBody()));
-        } catch(Exception ex) {
-            future.completeExceptionally(ex);
-        } finally {
-            return future;
-        }
+        ResponseEntity<JsonNode> rEntity =
+            restClient.exchange(requestType.getRequestURI(useBaseURI),
+                HttpMethod.GET, entity, JsonNode.class);
+        return BootstrapResultParser.parse(rEntity.getBody());
     }
 }

--- a/src/main/java/net/apnic/rdap/nro/config/NROConfiguration.java
+++ b/src/main/java/net/apnic/rdap/nro/config/NROConfiguration.java
@@ -1,7 +1,9 @@
 package net.apnic.rdap.nro.config;
 
+import net.apnic.rdap.authority.RDAPAuthorityStore;
 import net.apnic.rdap.nro.scraper.NROScraper;
 
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.context.properties.ConfigurationProperties;
@@ -23,13 +25,14 @@ public class NROConfiguration
 
     @ConditionalOnProperty(value="rdap.scraping.scrapers.nro.enabled")
     @Bean(value="nro")
-    public NROScraper nroScraper()
+    @Autowired
+    public NROScraper nroScraper(RDAPAuthorityStore rdapAuthorityStore)
     {
         if(baseURI != null && baseURI.isEmpty() == false)
         {
-            return new NROScraper(baseURI);
+            return new NROScraper(rdapAuthorityStore, baseURI);
         }
-        return new NROScraper();
+        return new NROScraper(rdapAuthorityStore);
     }
 
     public void setBaseURI(String baseURI)

--- a/src/main/java/net/apnic/rdap/nro/scraper/NROScraper.java
+++ b/src/main/java/net/apnic/rdap/nro/scraper/NROScraper.java
@@ -1,71 +1,27 @@
 package net.apnic.rdap.nro.scraper;
 
-import java.net.URI;
-import java.net.URISyntaxException;
-import java.util.logging.Level;
-import java.util.logging.Logger;
-
-import net.apnic.rdap.autnum.AsnRange;
 import net.apnic.rdap.authority.RDAPAuthorityStore;
-import net.apnic.rdap.resource.store.ResourceStorage;
 import net.apnic.rdap.stats.scraper.DelegatedStatsScraper;
 
-import net.ripe.ipresource.IpRange;
+import java.net.URI;
 
 /**
  * Scraper for NRO delegated stats.
  */
-public class NROScraper
-    extends DelegatedStatsScraper
-{
-    public static final URI NRO_STATS_URI;
+public class NROScraper extends DelegatedStatsScraper {
+    private static final String NRO_STATS_URI =
+            "https://www.nro.net/wp-content/uploads/apnic-uploads/delegated-extended";
 
-    private static final Logger LOGGER =
-        Logger.getLogger(NROScraper.class.getName());
-
-    static
-    {
-        URI nroStatsURI = null;
-
-        try
-        {
-            nroStatsURI = new URI("https://www.nro.net/wp-content/uploads/apnic-uploads/delegated-extended");
-        }
-        catch(URISyntaxException ex)
-        {
-            LOGGER.log(Level.SEVERE, "Exception when generating NRO uri", ex);
-        }
-        finally
-        {
-            NRO_STATS_URI = nroStatsURI;
-        }
+    public NROScraper(RDAPAuthorityStore rdapAuthorityStore) {
+        this(rdapAuthorityStore, NRO_STATS_URI);
     }
 
-    /**
-     * Takes the needed value to construct a valid delegated stats scraper.
-     *
-     * @param authorityStore Store for finding authorities while scraping
-     * @param asnStore Store for asn records to insert discovered resources in
-     *                 while scraping
-     * @param ipStore Store for ip records to insert discovered resources in
-     *                while scraping
-     */
-    public NROScraper()
-    {
-        super(NRO_STATS_URI);
+    public NROScraper(RDAPAuthorityStore rdapAuthorityStore, String uri) {
+        super(rdapAuthorityStore, URI.create(uri));
     }
 
-    public NROScraper(String uri)
-    {
-        super(URI.create(uri));
-    }
-
-    /**
-     * {@inheritDocs}
-     */
     @Override
-    public String getName()
-    {
+    public String getName() {
         return "nro-scraper";
     }
 }

--- a/src/main/java/net/apnic/rdap/resource/ResourceMapping.java
+++ b/src/main/java/net/apnic/rdap/resource/ResourceMapping.java
@@ -1,0 +1,40 @@
+package net.apnic.rdap.resource;
+
+import net.apnic.rdap.authority.RDAPAuthority;
+
+import java.util.Objects;
+
+/**
+ * Represents the mapping from a resource (IP, ANS or Domain) to a {@link net.apnic.rdap.authority.RDAPAuthority}.
+ */
+public class ResourceMapping<Resource> {
+    final private Resource resource;
+    final private RDAPAuthority authority;
+
+    public ResourceMapping(Resource resource, RDAPAuthority authority) {
+        this.resource = resource;
+        this.authority = authority;
+    }
+
+    public Resource getResource() {
+        return resource;
+    }
+
+    public RDAPAuthority getAuthority() {
+        return authority;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        ResourceMapping<?> that = (ResourceMapping<?>) o;
+        return Objects.equals(resource, that.resource) &&
+                Objects.equals(authority, that.authority);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(resource, authority);
+    }
+}

--- a/src/main/java/net/apnic/rdap/resource/store/ResourceStore.java
+++ b/src/main/java/net/apnic/rdap/resource/store/ResourceStore.java
@@ -122,4 +122,16 @@ public class ResourceStore
             putFunction.accept(resourceMapping.getResource(), resourceMapping.getAuthority());
         }
     }
+
+    public ResourceStorage<AsnRange> getAsnStorage() {
+        return asnStorage;
+    }
+
+    public ResourceStorage<Domain> getDomainStorage() {
+        return domainStorage;
+    }
+
+    public ResourceStorage<IpRange> getIpStorage() {
+        return ipStorage;
+    }
 }

--- a/src/main/java/net/apnic/rdap/scraper/Scraper.java
+++ b/src/main/java/net/apnic/rdap/scraper/Scraper.java
@@ -1,10 +1,5 @@
 package net.apnic.rdap.scraper;
 
-import java.util.concurrent.CompletableFuture;
-
-import net.apnic.rdap.authority.RDAPAuthorityStore;
-import net.apnic.rdap.resource.store.ResourceStore;
-
 /**
  * Generic interface that scrapers must conform to.
  */
@@ -13,14 +8,12 @@ public interface Scraper
     /**
      * Name of the scraper used for debuging and error logging purposes.
      */
-    public String getName();
+    String getName();
 
     /**
-     * Main worker method that gets called by the scheduler for each scraper.
-     *
-     * @param store Resource storage to placed scraped results into
-     * @return Future that is fulfilled when the scraper finishes its tasks.
+     * Triggers the scraper to fetch data.
+     * @return a {@link ScraperResult} containing the fetched data
+     * @throws ScraperException if an exception occurs during the scraper's execution
      */
-    public CompletableFuture<Void> start(ResourceStore resourceStore,
-                                         RDAPAuthorityStore authorityStore);
+    ScraperResult fetchData() throws ScraperException;
 }

--- a/src/main/java/net/apnic/rdap/scraper/ScraperException.java
+++ b/src/main/java/net/apnic/rdap/scraper/ScraperException.java
@@ -1,0 +1,14 @@
+package net.apnic.rdap.scraper;
+
+/**
+ * Signals an exception when a {@link Scraper} is processing data.
+ */
+public class ScraperException extends Exception {
+    public ScraperException(String message) {
+        super(message);
+    }
+
+    public ScraperException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/src/main/java/net/apnic/rdap/scraper/ScraperResult.java
+++ b/src/main/java/net/apnic/rdap/scraper/ScraperResult.java
@@ -1,0 +1,38 @@
+package net.apnic.rdap.scraper;
+
+import net.apnic.rdap.autnum.AsnRange;
+import net.apnic.rdap.domain.Domain;
+import net.apnic.rdap.resource.ResourceMapping;
+import net.ripe.ipresource.IpRange;
+
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * Encapsulates the total data retrieved by a {@link Scraper}.
+ */
+public class ScraperResult {
+    final private List<ResourceMapping<IpRange>> ipMappings;
+    final private List<ResourceMapping<AsnRange>> asnMappings;
+    final private List<ResourceMapping<Domain>> domainMappings;
+
+    public ScraperResult(List<ResourceMapping<IpRange>> ipMappings,
+                         List<ResourceMapping<AsnRange>> asnMappings,
+                         List<ResourceMapping<Domain>> domainMappings) {
+        this.ipMappings = ipMappings;
+        this.asnMappings = asnMappings;
+        this.domainMappings = domainMappings;
+    }
+
+    public Optional<List<ResourceMapping<IpRange>>> getIpMappings() {
+        return Optional.ofNullable(ipMappings);
+    }
+
+    public Optional<List<ResourceMapping<AsnRange>>> getAsnMappings() {
+        return Optional.ofNullable(asnMappings);
+    }
+
+    public Optional<List<ResourceMapping<Domain>>> getDomainMappings() {
+        return Optional.ofNullable(domainMappings);
+    }
+}

--- a/src/main/java/net/apnic/rdap/stats/scraper/DelegatedStatsScraper.java
+++ b/src/main/java/net/apnic/rdap/stats/scraper/DelegatedStatsScraper.java
@@ -118,7 +118,7 @@ public abstract class DelegatedStatsScraper implements Scraper {
      * Function is async and returns a future with a stream of the data returned
      * from the request.
      *
-     * @return Future containing a stream of the data recieved from the server
+     * @return a stream of the data received from the server
      */
     private InputStream makeDelegatedHttpRequest() {
         HttpEntity<Resource> entity = new HttpEntity<>(requestHeaders);

--- a/src/main/java/net/apnic/rdap/stats/scraper/DelegatedStatsScraper.java
+++ b/src/main/java/net/apnic/rdap/stats/scraper/DelegatedStatsScraper.java
@@ -1,44 +1,31 @@
 package net.apnic.rdap.stats.scraper;
 
-import java.io.InputStream;
-import java.io.IOException;
-import java.net.URI;
-import java.net.URISyntaxException;
-import java.util.Arrays;
-import java.util.concurrent.CompletableFuture;
-import java.util.logging.Level;
-import java.util.logging.Logger;
-import java.util.Scanner;
-
 import net.apnic.rdap.authority.RDAPAuthority;
 import net.apnic.rdap.authority.RDAPAuthorityStore;
 import net.apnic.rdap.autnum.AsnRange;
-import net.apnic.rdap.resource.store.ResourceStore;
+import net.apnic.rdap.resource.ResourceMapping;
 import net.apnic.rdap.scraper.Scraper;
-import net.apnic.rdap.stats.parser.AsnRecord;
-import net.apnic.rdap.stats.parser.DelegatedStatsException;
+import net.apnic.rdap.scraper.ScraperException;
+import net.apnic.rdap.scraper.ScraperResult;
 import net.apnic.rdap.stats.parser.DelegatedStatsParser;
-import net.apnic.rdap.stats.parser.IPRecord;
 import net.apnic.rdap.stats.parser.ResourceRecord;
-
 import net.ripe.ipresource.IpRange;
-
 import org.springframework.core.io.Resource;
-import org.springframework.http.HttpEntity;
-import org.springframework.http.HttpHeaders;
-import org.springframework.http.HttpMethod;
-import org.springframework.http.MediaType;
-import org.springframework.http.ResponseEntity;
-import org.springframework.util.concurrent.ListenableFuture;
-import org.springframework.web.client.RestClientException;
+import org.springframework.http.*;
 import org.springframework.web.client.RestTemplate;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
 
 /**
  * Abstract scraper for fetching delegated stats files and parsing the results.
  */
-public abstract class DelegatedStatsScraper
-    implements Scraper
-{
+public abstract class DelegatedStatsScraper implements Scraper {
     /**
      * Enum contains the supported schemas that can be used as a delegated stats
      * URI.
@@ -50,8 +37,7 @@ public abstract class DelegatedStatsScraper
 
         private final String scheme;
 
-        private SupportedScheme(String scheme)
-        {
+        SupportedScheme(String scheme) {
             this.scheme = scheme;
         }
 
@@ -62,13 +48,11 @@ public abstract class DelegatedStatsScraper
         }
     }
 
-    private final Logger LOGGER =
-        Logger.getLogger(DelegatedStatsScraper.class.getName());
-
     private HttpHeaders requestHeaders = null;
     private RestTemplate restClient = null;
     private SupportedScheme statsScheme = null;
     private URI statsURI = null;
+    private RDAPAuthorityStore rdapAuthorityStore;
 
     /**
      * Construct initialises this DelegatedStatsScraper with an already
@@ -76,20 +60,17 @@ public abstract class DelegatedStatsScraper
      *
      * The supplied statsURI must have a scheme that is in SupportedScheme.
      *
+     * @param rdapAuthorityStore instance of {@link RDAPAuthorityStore} to retrieve {@link RDAPAuthority} data
      * @param statsURI URI to fetch delegated stats from
      * @throws IllegalArgumentException Thrown when the URI scheme is not
      *                                  supported.
      */
-    public DelegatedStatsScraper(URI statsURI)
-    {
-        try
-        {
-            SupportedScheme scheme =
-                SupportedScheme.valueOf(statsURI.getScheme().toUpperCase());
-            this.statsScheme = scheme;
-        }
-        catch(IllegalArgumentException ex)
-        {
+    public DelegatedStatsScraper(RDAPAuthorityStore rdapAuthorityStore, URI statsURI) {
+        this.rdapAuthorityStore = rdapAuthorityStore;
+
+        try {
+            this.statsScheme = SupportedScheme.valueOf(statsURI.getScheme().toUpperCase());
+        } catch(IllegalArgumentException ex) {
             throw new IllegalArgumentException("Non support scheme for URI");
         }
 
@@ -103,37 +84,14 @@ public abstract class DelegatedStatsScraper
      *
      * Constructs a new URI object from the provided string.
      *
+     * @param rdapAuthorityStore instance of {@link RDAPAuthorityStore} to retrieve {@link RDAPAuthority} data
      * @param statsURI URI to fetch delegated stats from
      * @throws URISyntaxException Then a URI object cannot be constructed from
      *                            statsURI
-     * @see DelegatedStatsScraper(URI statsURI)
+     * @see DelegatedStatsScraper#DelegatedStatsScraper(RDAPAuthorityStore, URI)
      */
-    public DelegatedStatsScraper(String statsURI)
-        throws URISyntaxException
-    {
-        this(new URI(statsURI));
-    }
-
-    /**
-     * Callback to handle a discovered autnum record from a delegated stats
-     * file.
-     *
-     * @param record Asn record from a delegated stats file.
-     */
-    private void handleAutnumRecord(AsnRecord record, ResourceStore store,
-                                    RDAPAuthorityStore authorityStore)
-    {
-        try
-        {
-            store.putAutnumMapping(record.toAsnRange(),
-                recordAuthority(record, authorityStore));
-        }
-        catch(Exception ex)
-        {
-            LOGGER.log(Level.WARNING,
-                "Exception when inserting delegated stats autnum record for "
-                + getName() + " ", ex);
-        }
+    public DelegatedStatsScraper(RDAPAuthorityStore rdapAuthorityStore, String statsURI) throws URISyntaxException {
+        this(rdapAuthorityStore, new URI(statsURI));
     }
 
     /**
@@ -141,46 +99,16 @@ public abstract class DelegatedStatsScraper
      * inserting that record into a provided resource store.
      *
      * @param resourceRecord Resource record to handle
-     * @param resource The derived resource from a resourceRecord that gets
-     * 
-     *                 inserted into the provided resourceStore
-     * @param resourceStore The Resource store to insert the resource into with
-     *                      the authority discovered through the resourceRecord
      */
-    private RDAPAuthority recordAuthority(ResourceRecord resourceRecord,
-                                         RDAPAuthorityStore authorityStore)
-    {
-        RDAPAuthority authority =
-            authorityStore.findAuthority(resourceRecord.getRegistry());
+    private RDAPAuthority recordAuthority(ResourceRecord resourceRecord) {
+        RDAPAuthority authority = rdapAuthorityStore.findAuthority(resourceRecord.getRegistry());
 
         if(authority == null)
         {
-            authority = authorityStore.createAuthority(
+            authority = rdapAuthorityStore.createAuthority(
                 resourceRecord.getRegistry());
         }
         return authority;
-    }
-
-    /**
-     * Callback to handle a discovered ip record from a delegated stats
-     * file.
-     *
-     * @param record IP record from a delegated stats file.
-     */
-    private void handleIPRecord(IPRecord record, ResourceStore store,
-                                RDAPAuthorityStore authorityStore)
-    {
-        try
-        {
-            store.putIPMapping(record.toIPRange(),
-                               recordAuthority(record, authorityStore));
-        }
-        catch(Exception ex)
-        {
-            LOGGER.log(Level.WARNING,
-                "Exception when inserting delegated stats ip network record for "
-                + getName() + " ", ex);
-        }
     }
 
     /**
@@ -192,35 +120,17 @@ public abstract class DelegatedStatsScraper
      *
      * @return Future containing a stream of the data recieved from the server
      */
-    private CompletableFuture<InputStream> makeDelegatedHttpRequest()
-    {
-        HttpEntity<Resource> entity = new HttpEntity<Resource>(requestHeaders);
-        CompletableFuture<ResponseEntity<Resource>> future =
-            new CompletableFuture<ResponseEntity<Resource>>();
+    private InputStream makeDelegatedHttpRequest() {
+        HttpEntity<Resource> entity = new HttpEntity<>(requestHeaders);
 
-        try
-        {
+        try {
             ResponseEntity<Resource> rVal =
                 restClient.exchange(statsURI, HttpMethod.GET,
                                     entity, Resource.class);
-            future.complete(rVal);
+            return rVal.getBody().getInputStream();
+        } catch (IOException e) {
+            throw new RuntimeException(e);
         }
-        catch(RestClientException ex)
-        {
-            future.completeExceptionally(ex);
-        }
-
-        return future.thenApply((ResponseEntity<Resource> responseEntity) ->
-            {
-                try
-                {
-                    return responseEntity.getBody().getInputStream();
-                }
-                catch(IOException ex)
-                {
-                    throw new RuntimeException(ex);
-                }
-            });
     }
 
     /**
@@ -234,38 +144,30 @@ public abstract class DelegatedStatsScraper
         requestHeaders.add(HttpHeaders.USER_AGENT, "");
     }
 
-    /**
-     * {@inheritDocs}
-     */
     @Override
-    public CompletableFuture<Void> start(ResourceStore store,
-                                         RDAPAuthorityStore authorityStore)
-    {
-        CompletableFuture<InputStream> request = null;
-
+    public ScraperResult fetchData() throws ScraperException {
         if(statsScheme == SupportedScheme.HTTP ||
            statsScheme == SupportedScheme.HTTPS)
         {
-            request = makeDelegatedHttpRequest();
-        }
+            InputStream response = makeDelegatedHttpRequest();
+            List<ResourceMapping<IpRange>> ipMappings = new ArrayList<>();
+            List<ResourceMapping<AsnRange>> asnMappings = new ArrayList<>();
 
-        return request
-            .thenAccept((InputStream iStream) ->
-            {
-                try
-                {
-                    DelegatedStatsParser.parse(iStream,
-                        asnRecord -> handleAutnumRecord(asnRecord, store,
-                                                        authorityStore),
-                        ipRecord -> handleIPRecord(ipRecord, store,
-                                                   authorityStore),
-                        ipRecord -> handleIPRecord(ipRecord, store,
-                                                   authorityStore));
-                }
-                catch(Exception ex)
-                {
-                    throw new RuntimeException(ex);
-                }
-            });
+            try {
+                DelegatedStatsParser.parse(response,
+                        asnRecord -> asnMappings.add(new ResourceMapping<AsnRange>(asnRecord.toAsnRange(),
+                                recordAuthority(asnRecord))),
+                        ipRecord -> ipMappings.add(new ResourceMapping<>(ipRecord.toIPRange(),
+                                recordAuthority(ipRecord))),
+                        ipRecord -> ipMappings.add(new ResourceMapping<>(ipRecord.toIPRange(),
+                                recordAuthority(ipRecord))));
+            } catch (Exception ex) {
+                throw new ScraperException("Error running delegated stats scrapper: ", ex);
+            }
+
+            return new ScraperResult(ipMappings, asnMappings, null);
+        } else {
+            throw new ScraperException("Stats scheme not supported: " + statsScheme);
+        }
     }
 }

--- a/src/main/resources/application-rdap.yml
+++ b/src/main/resources/application-rdap.yml
@@ -65,6 +65,7 @@ rdap:
                 enabled: true
             nro:
                 enabled: true
+                baseURI: https://labs.apnic.net/delegated-nro-extended
         config:
             # Order in which scrapers are run.
             order:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -14,6 +14,11 @@ endpoints:
     post:
       enabled: false
 
+# required for displaying health endpoint details
+management:
+  security:
+    enabled: false
+
 server:
   use-forward-headers: true
   port: 8080

--- a/src/test/java/net/apnic/rdap/scraper/ScraperSchedulerTest.java
+++ b/src/test/java/net/apnic/rdap/scraper/ScraperSchedulerTest.java
@@ -1,0 +1,96 @@
+package net.apnic.rdap.scraper;
+
+import net.apnic.rdap.authority.RDAPAuthority;
+import net.apnic.rdap.autnum.AutnumStatsResourceLocator;
+import net.apnic.rdap.domain.DomainStatsResourceLocator;
+import net.apnic.rdap.ip.IPStatsResourceLocator;
+import net.apnic.rdap.resource.ResourceMapping;
+import net.apnic.rdap.resource.ResourceNotFoundException;
+import net.apnic.rdap.resource.store.ResourceStore;
+import net.ripe.ipresource.IpRange;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.Collections;
+import java.util.List;
+
+import static org.hamcrest.Matchers.*;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+import static org.junit.Assert.*;
+
+class ScraperSchedulerTest {
+
+    private ScraperScheduler scraperScheduler;
+    private ResourceStore resourceStore;
+
+    @BeforeEach
+    void setup() {
+        IPStatsResourceLocator ipStatsResourceLocator = new IPStatsResourceLocator();
+
+        resourceStore = new ResourceStore(
+                new AutnumStatsResourceLocator(),
+                new DomainStatsResourceLocator(ipStatsResourceLocator),
+                ipStatsResourceLocator
+        );
+
+        scraperScheduler = new ScraperScheduler(resourceStore);
+    }
+
+    @Test
+    void testFullScenarioForDataFetching() throws ScraperException, ResourceNotFoundException {
+        final RDAPAuthority RDAP_AUTHORITY = new RDAPAuthority("test");
+        final RDAPAuthority RDAP_AUTHORITY2 = new RDAPAuthority("test2");
+        final IpRange IP_RANGE = IpRange.parse("128.0.0.0/24");
+        final String SCRAPER_NAME = "scraper_test";
+
+        Scraper scraper = mock(Scraper.class);
+        when(scraper.getName()).thenReturn(SCRAPER_NAME);
+        scraperScheduler.addScraper(scraper);
+
+        List<ResourceMapping<IpRange>> ipMappings =
+                Collections.singletonList(new ResourceMapping<>(IP_RANGE, RDAP_AUTHORITY));
+        ScraperResult result = new ScraperResult(ipMappings, null, null);
+
+        // before fetching data
+        assertThrows(ResourceNotFoundException.class,
+                () -> ((IPStatsResourceLocator) resourceStore.getIpStorage()).authorityForResource(IP_RANGE));
+        assertThat(scraperScheduler.health().toString(), containsString("status=PENDING"));
+
+        // fetch data
+        when(scraper.fetchData()).thenReturn(result);
+        scraperScheduler.processDataUpdate().run();
+
+        // after successfully fetching data
+        RDAPAuthority rdapAuthorityReturned =
+                ((IPStatsResourceLocator) resourceStore.getIpStorage()).authorityForResource(IP_RANGE);
+        assertThat(rdapAuthorityReturned, not(nullValue()));
+        assertThat(rdapAuthorityReturned, equalTo(RDAP_AUTHORITY));
+        assertThat(scraperScheduler.health().toString(), containsString("status=SUCCESS"));
+
+        // fail data fetching
+        when(scraper.fetchData()).thenThrow(ScraperException.class);
+        scraperScheduler.processDataUpdate().run();
+
+        // after failed data fetching
+        rdapAuthorityReturned =
+                ((IPStatsResourceLocator) resourceStore.getIpStorage()).authorityForResource(IP_RANGE);
+        assertThat(rdapAuthorityReturned, not(nullValue()));
+        assertThat(rdapAuthorityReturned, equalTo(RDAP_AUTHORITY));
+        assertThat(scraperScheduler.health().toString(), containsString("status=FAILURE"));
+
+        // subsequent successful data fetching
+        ipMappings = Collections.singletonList(new ResourceMapping<>(IP_RANGE, RDAP_AUTHORITY2));
+        result = new ScraperResult(ipMappings, null, null);
+        reset(scraper);
+        when(scraper.getName()).thenReturn(SCRAPER_NAME);
+        when(scraper.fetchData()).thenReturn(result);
+        scraperScheduler.processDataUpdate().run();
+
+        // after successfully fetching data
+        rdapAuthorityReturned = ((IPStatsResourceLocator) resourceStore.getIpStorage()).authorityForResource(IP_RANGE);
+        assertThat(rdapAuthorityReturned, not(nullValue()));
+        assertThat(rdapAuthorityReturned, equalTo(RDAP_AUTHORITY2));
+        assertThat(scraperScheduler.health().toString(), containsString("status=SUCCESS"));
+    }
+}


### PR DESCRIPTION
From the ticket:
Currently in rdap-ingressd, if one of the two scrapers can't access its
sources, it is not considered anymore for the routing. We need to
allow the last data downloaded from these sources until it can be
access again. Besides we also need to create a health endpoint so we
can allow monitoring the service and check if their data sources are
updated.

In addition we also have implemented a health endpoint for allowing
monitoring the scrapers status.

QA Reviewer: @GKTheOne 

QA Steps:
`ScraperSchedulerTest.java` should cover the changes introduced by this story.